### PR TITLE
pahma/ucjeps/botgarden: use config from blacklight.yml to read solr q…

### DIFF
--- a/ucb_extras/botgarden/app/helpers/application_helper.rb
+++ b/ucb_extras/botgarden/app/helpers/application_helper.rb
@@ -89,7 +89,8 @@ module ApplicationHelper
     solr_params.each do |k,v|
       endpoint_params+="#{k} : #{v} "
     end
-    url_string = "https://webapps.cspace.berkeley.edu/solr/botgarden-public/select?defType=edismax&df=text&q.op=AND&q=#{endpoint_params}"
+    solr_url = Rails.application.config.blacklight_solr['url'].to_s
+    url_string = solr_url+"/select?defType=edismax&df=text&q.op=AND&q=#{endpoint_params}"
     url_string = url_string.gsub("'","%22").gsub(" ","%20")
     # puts url_string
     

--- a/ucb_extras/botgarden/config/application.rb
+++ b/ucb_extras/botgarden/config/application.rb
@@ -37,7 +37,9 @@ module Portal
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-
+    # read the correct URL for requerying solr from portal/config/blacklight.yml
+    config.blacklight_solr = config_for(:blacklight)
+    
     # hash that defines the fields used in outputting search results to a csv
     config.csv_output_fields = {
       "objcsid_s" => "Object CSID",

--- a/ucb_extras/pahma/app/helpers/application_helper.rb
+++ b/ucb_extras/pahma/app/helpers/application_helper.rb
@@ -78,6 +78,7 @@ module ApplicationHelper
     solr_params.each do |k,v|
       endpoint_params+="#{k} : #{v} "
     end
+    
     url_string = "https://webapps.cspace.berkeley.edu/solr/pahma-public/select?defType=edismax&df=text&q.op=AND&q=#{endpoint_params}"
     url_string = url_string.gsub("'","%22").gsub(" ","%20")
     # puts url_string

--- a/ucb_extras/pahma/config/application.rb
+++ b/ucb_extras/pahma/config/application.rb
@@ -29,6 +29,9 @@ module Portal
     config.sass.quiet_deps = true
     config.sass.silence_deprecations = ['import']
 
+    # read the correct URL for requerying solr from portal/config/blacklight.yml
+    config.blacklight_solr = config_for(:blacklight)
+    
     # hash that defines the fields used in outputting search results to a csv
     config.csv_output_fields = {
       "csid_s" => "Object CSID",

--- a/ucb_extras/ucjeps/app/helpers/application_helper.rb
+++ b/ucb_extras/ucjeps/app/helpers/application_helper.rb
@@ -89,7 +89,8 @@ module ApplicationHelper
     solr_params.each do |k,v|
       endpoint_params+="#{k} : #{v} "
     end
-    url_string = "https://webapps.cspace.berkeley.edu/solr/ucjeps-public/select?defType=edismax&df=text&q.op=AND&q=#{endpoint_params}"
+    solr_url = Rails.application.config.blacklight_solr['url'].to_s
+    url_string = solr_url+"/select?defType=edismax&df=text&q.op=AND&q=#{endpoint_params}"
     url_string = url_string.gsub("'","%22").gsub(" ","%20")
     puts url_string
     

--- a/ucb_extras/ucjeps/config/application.rb
+++ b/ucb_extras/ucjeps/config/application.rb
@@ -38,6 +38,9 @@ module Portal
     # config.eager_load_paths << Rails.root.join("extras")
 
 
+    # read the correct URL for requerying solr from portal/config/blacklight.yml
+    config.blacklight_solr = config_for(:blacklight)
+    
     # hash that defines the fields used in outputting search results to a csv
     config.csv_output_fields = {
       "accessionnumber_s"=>"Accession Number",


### PR DESCRIPTION
…uery endpoint url, rather than use hardcoded url for search csv download and stats creation/download